### PR TITLE
Fix NullPointerException when no anchor is defined

### DIFF
--- a/src/main/java/fr/jmini/asciidoctorj/dynamicinclude/DynamicIncludeProcessor.java
+++ b/src/main/java/fr/jmini/asciidoctorj/dynamicinclude/DynamicIncludeProcessor.java
@@ -446,9 +446,9 @@ public class DynamicIncludeProcessor extends IncludeProcessor {
             } else {
                 newFileName = "";
             }
-            if (findFile.isPresent() && holder.getAnchor()
+            if (findFile.isPresent() && (holder.getAnchor() == null || holder.getAnchor()
                     .trim()
-                    .isEmpty()) {
+                    .isEmpty())) {
                 newAnchor = findFile.get()
                         .getTitleId();
             }

--- a/src/test/java/fr/jmini/asciidoctorj/dynamicinclude/DynamicIncludeProcessorTest.java
+++ b/src/test/java/fr/jmini/asciidoctorj/dynamicinclude/DynamicIncludeProcessorTest.java
@@ -149,6 +149,9 @@ public class DynamicIncludeProcessorTest {
         String otherLinkMutiple = DynamicIncludeProcessor.replaceXrefInlineLinks("See xref:other.adoc#foo[link 1] and xref:other.adoc#bar[link 2] for more info", list, dir, page1, dir, true);
         assertThat(otherLinkMutiple).isEqualTo("See xref:#foo[link 1] and xref:#bar[link 2] for more info");
 
+        String otherNoHashLink = DynamicIncludeProcessor.replaceXrefInlineLinks("Some xref:other.adoc[valuable] link", list, dir, page1, dir, true);
+        assertThat(otherNoHashLink).isEqualTo("Some xref:#_other_page[valuable] link");
+
         String internalLink = DynamicIncludeProcessor.replaceXrefDoubleAngledBracketLinks("Some xref:#test[internal] link", list, dir, page1, dir, true);
         assertThat(internalLink).isEqualTo("Some xref:#test[internal] link");
 


### PR DESCRIPTION
Follow up of #3, when the anchor is not defined it produces a `NullPointerException` in some cases.